### PR TITLE
Added definitions on AIX for internal time.

### DIFF
--- a/include/boost/chrono/io/time_point_io.hpp
+++ b/include/boost/chrono/io/time_point_io.hpp
@@ -39,13 +39,15 @@
   || (defined(sun) || defined(__sun)) \
   || (defined __IBMCPP__) \
   || defined __ANDROID__ \
-  || defined __QNXNTO__
+  || defined __QNXNTO__ \
+  || (defined(_AIX) && defined __GNUC__)
 
 #define  BOOST_CHRONO_INTERNAL_GMTIME \
      (defined BOOST_WINDOWS && ! defined(__CYGWIN__)) \
   || ( (defined(sun) || defined(__sun)) && defined __GNUC__) \
   || (defined __IBMCPP__) \
-  || defined __ANDROID__
+  || defined __ANDROID__ \
+  || (defined(_AIX) && defined __GNUC__)
 
 #define  BOOST_CHRONO_USES_INTERNAL_TIME_GET
 


### PR DESCRIPTION
A declaration of timegm was not found for AIX resulting in a compilation failure. Both #define  BOOST_CHRONO_INTERNAL_TIMEGM and #define  BOOST_CHRONO_INTERNAL_GMTIME do not take into account the AIX platform even though in the AIX platform it works the same way in all the previously listed platforms.
