### PR TITLE
For clang set warnings to on and remove -pedantic.

### DIFF
--- a/build/Jamfile.v2
+++ b/build/Jamfile.v2
@@ -46,9 +46,9 @@ project boost/chrono
         <toolset>pathscale:<cxxflags>-Wno-long-long
         <toolset>pathscale:<cxxflags>-pedantic
         <toolset>clang:<cxxflags>-Wextra
-        <toolset>clang:<cxxflags>-pedantic
         <toolset>clang:<cxxflags>-Wno-long-long
         <toolset>clang:<cxxflags>-Wno-variadic-macros
+        <toolset>clang:<warnings>on
         <toolset>gcc-4.4.0,<target-os>windows:<cxxflags>-fdiagnostics-show-option 
  	<toolset>gcc-4.5.0,<target-os>windows:<cxxflags>-fdiagnostics-show-option 
  	<toolset>gcc-4.6.0,<target-os>windows:<cxxflags>-fdiagnostics-show-option 


### PR DESCRIPTION
Clang should be set warnings to on without '-pedantic' to avoid many Boost PP warnings.
