### PR TITLE
Fix chrono to support GCC 3.x

### DIFF
--- a/build/Jamfile.v2
+++ b/build/Jamfile.v2
@@ -49,7 +49,8 @@ project boost/chrono
         <toolset>clang:<cxxflags>-Wextra
         <toolset>clang:<cxxflags>-pedantic
         <toolset>clang:<cxxflags>-Wno-long-long
-        <toolset>clang:<cxxflags>-Wno-variadic-macros
+        <toolset>gcc-4:<cxxflags>-Wno-variadic-macros
+        <toolset>gcc-5:<cxxflags>-Wno-variadic-macros
         <toolset>gcc-4.4.0,<target-os>windows:<cxxflags>-fdiagnostics-show-option 
  	<toolset>gcc-4.5.0,<target-os>windows:<cxxflags>-fdiagnostics-show-option 
  	<toolset>gcc-4.6.0,<target-os>windows:<cxxflags>-fdiagnostics-show-option 


### PR DESCRIPTION
According to the latest compiler deprecation GCC 3.3 is still (in theory) supported. I'm trying to put a regression runner with mingw-3.4 and it seems that "-Wno-variadic-macros" was introduced with GCC 4.0 and compilation fails because of this. With this patch the library compiles fine.