### PR TITLE
fix a mistake in process_times<Rep>::read()

### DIFF
--- a/include/boost/chrono/process_cpu_clocks.hpp
+++ b/include/boost/chrono/process_cpu_clocks.hpp
@@ -193,7 +193,7 @@ namespace boost { namespace chrono {
                 typedef std::istreambuf_iterator<CharT, Traits> in_iterator;
                 in_iterator i(is);
                 in_iterator e;
-                if (i == e || *i != '{')  // mandatory '{'
+                if (i == e || *i++ != '{')  // mandatory '{'
                 {
                     is.setstate(is.failbit | is.eofbit);
                     return;


### PR DESCRIPTION
In L202, the input stream will be used to retrieve values, but it does not ignore first character '{'