### PR TITLE
fix a bug in ios_state_ptr<>::release()

### DIFF
--- a/include/boost/chrono/io/utility/ios_base_state_ptr.hpp
+++ b/include/boost/chrono/io/utility/ios_base_state_ptr.hpp
@@ -164,9 +164,10 @@ namespace boost
        */
       T * release() BOOST_NOEXCEPT
       {
-        T const* f = get();
-        reset();
-        return f;
+        void*& pw = ios_.pword(index());
+        T* ptr = static_cast<T*> (pw);
+        pw = 0;
+        return ptr;
       }
 
       /**


### PR DESCRIPTION
This member function should transfer the ownership to caller, but it returns a dangling pointer.