### PR TITLE
Fix duration default constructor to be constexpr-safe.

### DIFF
--- a/include/boost/chrono/duration.hpp
+++ b/include/boost/chrono/duration.hpp
@@ -438,7 +438,7 @@ namespace chrono {
         BOOST_FORCEINLINE BOOST_CONSTEXPR
         duration() : rep_(duration_values<rep>::zero()) { }
 #else
-        BOOST_CONSTEXPR duration() BOOST_NOEXCEPT {};
+        BOOST_CONSTEXPR duration() BOOST_NOEXCEPT : rep_() {};
 #endif
         template <class Rep2>
         BOOST_SYMBOL_VISIBLE BOOST_FORCEINLINE BOOST_CONSTEXPR

--- a/test/duration/arithmetic_pass.cpp
+++ b/test/duration/arithmetic_pass.cpp
@@ -23,6 +23,11 @@
 
 int main()
 {
+  // Default construct
+   {
+      BOOST_CONSTEXPR boost::chrono::minutes m;
+      BOOST_CONSTEXPR_ASSERT(m.count() == 0);
+   }
 
   // UNARY PLUS
   {


### PR DESCRIPTION
Also add tests for the issue.