### PR TITLE
Hide Chrono.Stopwatch in library list

### DIFF
--- a/meta/libraries.json
+++ b/meta/libraries.json
@@ -20,6 +20,7 @@
   {
     "key": "chrono/stopwatch",
     "name": "Chrono.Stopwatch",
+    "status": "unreleased",
     "authors": [
       "Vicente J. Botet Escriba"
     ],


### PR DESCRIPTION
It's already hidden in the list, but I used a bit of a hack to do so, better to do it properly so I can remove that, and its visibility can be controlled in the repo.

Of course, if you want to add it to the library lists, then just ask. And this can wait until after the release, there's no rush.