### PR TITLE
Rename short all-capital typedefs to avoid name clashes with macros.

### DIFF
--- a/include/boost/chrono/duration.hpp
+++ b/include/boost/chrono/duration.hpp
@@ -542,8 +542,8 @@ namespace chrono {
           const duration<Rep2, Period2>& rhs)
     {
       typedef typename common_type<duration<Rep1, Period1>,
-        duration<Rep2, Period2> >::type CD;
-      return CD(CD(lhs).count()+CD(rhs).count());
+        duration<Rep2, Period2> >::type common_duration;
+      return common_duration(common_duration(lhs).count()+common_duration(rhs).count());
     }
 
     // Duration -
@@ -555,8 +555,8 @@ namespace chrono {
           const duration<Rep2, Period2>& rhs)
     {
       typedef typename common_type<duration<Rep1, Period1>,
-            duration<Rep2, Period2> >::type CD;
-      return CD(CD(lhs).count()-CD(rhs).count());
+            duration<Rep2, Period2> >::type common_duration;
+      return common_duration(common_duration(lhs).count()-common_duration(rhs).count());
     }
 
     // Duration *
@@ -572,9 +572,9 @@ namespace chrono {
     >::type
     operator*(const duration<Rep1, Period>& d, const Rep2& s)
     {
-      typedef typename common_type<Rep1, Rep2>::type CR;
-      typedef duration<CR, Period> CD;
-      return CD(CD(d).count()*static_cast<CR>(s));
+      typedef typename common_type<Rep1, Rep2>::type common_rep;
+      typedef duration<common_rep, Period> common_duration;
+      return common_duration(common_duration(d).count()*static_cast<common_rep>(s));
     }
 
     template <class Rep1, class Period, class Rep2>
@@ -601,10 +601,9 @@ namespace chrono {
     >::type
     operator/(const duration<Rep1, Period>& d, const Rep2& s)
     {
-        typedef typename common_type<Rep1, Rep2>::type CR;
-        typedef duration<CR, Period> CD;
-
-      return CD(CD(d).count()/static_cast<CR>(s));
+      typedef typename common_type<Rep1, Rep2>::type common_rep;
+      typedef duration<common_rep, Period> common_duration;
+      return common_duration(common_duration(d).count()/static_cast<common_rep>(s));
     }
 
     template <class Rep1, class Period1, class Rep2, class Period2>
@@ -613,8 +612,8 @@ namespace chrono {
     operator/(const duration<Rep1, Period1>& lhs, const duration<Rep2, Period2>& rhs)
     {
         typedef typename common_type<duration<Rep1, Period1>,
-                                   duration<Rep2, Period2> >::type CD;
-        return CD(lhs).count() / CD(rhs).count();
+                                   duration<Rep2, Period2> >::type common_duration;
+        return common_duration(lhs).count() / common_duration(rhs).count();
     }
 
     #ifdef BOOST_CHRONO_EXTENSIONS
@@ -626,10 +625,9 @@ namespace chrono {
       >::type
     operator/(const Rep1& s, const duration<Rep2, Period>& d)
     {
-        typedef typename common_type<Rep1, Rep2>::type CR;
-        typedef duration<CR, Period> CD;
-
-      return static_cast<CR>(s)/CD(d).count();
+      typedef typename common_type<Rep1, Rep2>::type common_rep;
+      typedef duration<common_rep, Period> common_duration;
+      return static_cast<common_rep>(s)/common_duration(d).count();
     }
     #endif
     // Duration %
@@ -642,10 +640,9 @@ namespace chrono {
     >::type
     operator%(const duration<Rep1, Period>& d, const Rep2& s)
     {
-        typedef typename common_type<Rep1, Rep2>::type CR;
-        typedef duration<CR, Period> CD;
-
-      return CD(CD(d).count()%static_cast<CR>(s));
+      typedef typename common_type<Rep1, Rep2>::type common_rep;
+      typedef duration<common_rep, Period> common_duration;
+      return common_duration(common_duration(d).count()%static_cast<common_rep>(s));
     }
 
     template <class Rep1, class Period1, class Rep2, class Period2>
@@ -654,9 +651,9 @@ namespace chrono {
     operator%(const duration<Rep1, Period1>& lhs,
           const duration<Rep2, Period2>& rhs) {
         typedef typename common_type<duration<Rep1, Period1>,
-                                 duration<Rep2, Period2> >::type CD;
+                                 duration<Rep2, Period2> >::type common_duration;
 
-      return CD(CD(lhs).count()%CD(rhs).count());
+      return common_duration(common_duration(lhs).count()%common_duration(rhs).count());
     }
 
 
@@ -671,8 +668,8 @@ namespace detail
     {
       BOOST_CONSTEXPR bool operator()(const LhsDuration& lhs, const RhsDuration& rhs) const
         {
-            typedef typename common_type<LhsDuration, RhsDuration>::type CD;
-            return CD(lhs).count() == CD(rhs).count();
+            typedef typename common_type<LhsDuration, RhsDuration>::type common_duration;
+            return common_duration(lhs).count() == common_duration(rhs).count();
         }
     };
 
@@ -690,8 +687,8 @@ namespace detail
     {
       BOOST_CONSTEXPR bool operator()(const LhsDuration& lhs, const RhsDuration& rhs) const
         {
-            typedef typename common_type<LhsDuration, RhsDuration>::type CD;
-            return CD(lhs).count() < CD(rhs).count();
+            typedef typename common_type<LhsDuration, RhsDuration>::type common_duration;
+            return common_duration(lhs).count() < common_duration(rhs).count();
         }
     };
 


### PR DESCRIPTION
In particular, CR is defined in apache2/httpd.h as a character of carriage return (13). CD is also potentially problematic, so rename it as well.
