### PR TITLE
Replace unsafe library function localtime by safe function localtime_…

### DIFF
--- a/include/boost/chrono/io/time_point_io.hpp
+++ b/include/boost/chrono/io/time_point_io.hpp
@@ -940,11 +940,15 @@ namespace boost
           if (tz == timezone::local)
           {
 #if defined BOOST_WINDOWS && ! defined(__CYGWIN__)
+#if BOOST_MSVC < 1400  // localtime_s doesn't exist in vc7.1
             std::tm *tmp = 0;
             if ((tmp=localtime(&t)) == 0)
               failed = true;
             else
               tm =*tmp;
+# else
+            if (localtime_s(&tm, &t) != 0) failed = true;
+# endif
 #else
             if (localtime_r(&t, &tm) == 0) failed = true;
 #endif


### PR DESCRIPTION
…s when compiled with msvc 8.0 or later.

Signed-off-by: Daniela Engert <dani@ngrt.de>