### PR TITLE
Uncomment include.

### DIFF
--- a/stopwatches/example/stopwatch_example.cpp
+++ b/stopwatches/example/stopwatch_example.cpp
@@ -6,7 +6,7 @@
 //  See http://www.boost.org/LICENSE_1_0.txt
 //  See http://www.boost.org/libs/chrono/stopwatches for documentation.
 
-//#include <iostream>
+#include <iostream>
 #include <boost/chrono/stopwatches/strict_stopwatch.hpp>
 #include <boost/chrono/chrono_io.hpp>
 #include <boost/chrono/process_cpu_clocks.hpp>


### PR DESCRIPTION
To compile two tests: `stopwatch_example_d` and `stopwatch_example_h` of [Boost regression: chrono/stopwatches/develop](http://www.boost.org/development/tests/develop/developer/chrono-stopwatches.html).

Tested with GCC 7.1.1 on Fedora rawhide.