### PR TITLE
Fix old GCC warning about attributes in declarations

### DIFF
--- a/include/boost/chrono/system_clocks.hpp
+++ b/include/boost/chrono/system_clocks.hpp
@@ -96,9 +96,9 @@ namespace boost {
 namespace chrono {
 
   // Clocks
-  class BOOST_CHRONO_DECL system_clock;
+  class system_clock;
 #ifdef BOOST_CHRONO_HAS_CLOCK_STEADY
-  class BOOST_CHRONO_DECL steady_clock;
+  class steady_clock;
 #endif
 
 #ifdef BOOST_CHRONO_HAS_CLOCK_STEADY


### PR DESCRIPTION
"warning: type attributes are honored only at type definition"