### PR TITLE
Work around lack of thread safety in cygwin CLOCK_MONOTONIC one-time initialization

### DIFF
--- a/include/boost/chrono/detail/inlined/posix/chrono.hpp
+++ b/include/boost/chrono/detail/inlined/posix/chrono.hpp
@@ -12,6 +12,7 @@
 
 #include <time.h>  // for clock_gettime
 #include <boost/assert.hpp>
+#include <boost/predef/os.h>
 
 namespace boost
 {
@@ -75,11 +76,20 @@ namespace chrono
   steady_clock::time_point steady_clock::now() BOOST_NOEXCEPT
   {
     timespec ts;
-    if ( ::clock_gettime( CLOCK_MONOTONIC, &ts ) )
+#if BOOST_OS_CYGWIN
+    // lack of thread safety in high resolution timer initialization
+    // can lead to a timespec of zero without an error; was reported
+    // to the cygwin mailing list and can be removed once fixed
+    do
     {
-      BOOST_ASSERT(0 && "Boost::Chrono - Internal Error");
-    }
-
+#endif
+      if ( ::clock_gettime( CLOCK_MONOTONIC, &ts ) )
+      {
+        BOOST_ASSERT(0 && "Boost::Chrono - Internal Error");
+      }
+#if BOOST_OS_CYGWIN
+    } while (ts.tv_sec == 0 && ts.tv_nsec == 0);
+#endif
     return time_point(duration(
       static_cast<steady_clock::rep>( ts.tv_sec ) * 1000000000 + ts.tv_nsec));
   }
@@ -88,8 +98,15 @@ namespace chrono
   steady_clock::time_point steady_clock::now(system::error_code & ec)
   {
     timespec ts;
-    if ( ::clock_gettime( CLOCK_MONOTONIC, &ts ) )
+#if BOOST_OS_CYGWIN
+    // lack of thread safety in high resolution timer initialization
+    // can lead to a timespec of zero without an error; was reported
+    // to the cygwin mailing list and can be removed once fixed
+    do
     {
+#endif
+      if ( ::clock_gettime( CLOCK_MONOTONIC, &ts ) )
+      {
         if (::boost::chrono::is_throws(ec))
         {
             boost::throw_exception(
@@ -103,7 +120,10 @@ namespace chrono
             ec.assign( errno, ::boost::system::system_category() );
             return time_point();
         }
-    }
+      }
+#if BOOST_OS_CYGWIN
+    } while (ts.tv_sec == 0 && ts.tv_nsec == 0);
+#endif
 
     if (!::boost::chrono::is_throws(ec))
     {


### PR DESCRIPTION
Observation:  Two threads calling boost::chrono::high_resolution_timer::now() on cygwin at roughly the same time will sometimes return a timespec of all zero.

Root cause: cygwin has no thread safety in their one-time hires_ns timer initialization.

I sent a message to their mailing list about it with an example (attached).

[cygwinrace.zip](https://github.com/boostorg/chrono/files/2611353/cygwinrace.zip)

This fixes #35 

I will apply the same fix to Boost.DateTime if necessary.  Once this is merged into develop we can continue qualifying appveyor improvements.