### PR TITLE
Remove linking with Boost.System

### DIFF
--- a/build/Jamfile.v2
+++ b/build/Jamfile.v2
@@ -15,9 +15,7 @@ project boost/chrono
         <target-os>linux:<linkflags>"-lrt -lpthread"
         <toolset>pgi:<linkflags>"-lrt"
         #<threading>single:<define>BOOST_CHRONO_THREAD_DISABLED
-        <library>/boost/system//boost_system
         #<define>BOOST_ERROR_CODE_HEADER_ONLY
-        #<define>BOOST_SYSTEM_INLINED
         #<define>BOOST_COMMON_TYPE_USES_STATIC_ASSERT
         #<define>BOOST_RATIO_USES_STATIC_ASSERT
         #<define>BOOST_CHRONO_USES_STATIC_ASSERT
@@ -54,11 +52,11 @@ project boost/chrono
         <toolset>clang:<cxxflags>-Wno-long-long
         <toolset>clang:<cxxflags>-Wno-variadic-macros
         <toolset>gcc-4.4.0,<target-os>windows:<cxxflags>-fdiagnostics-show-option 
- 	<toolset>gcc-4.5.0,<target-os>windows:<cxxflags>-fdiagnostics-show-option 
- 	<toolset>gcc-4.6.0,<target-os>windows:<cxxflags>-fdiagnostics-show-option 
- 	<toolset>gcc-4.6.3,<target-os>windows:<cxxflags>-fdiagnostics-show-option 
- 	<toolset>gcc-4.7.0,<target-os>windows:<cxxflags>-fdiagnostics-show-option 
- 	<toolset>gcc-4.8.0,<target-os>windows:<cxxflags>-fdiagnostics-show-option 
+        <toolset>gcc-4.5.0,<target-os>windows:<cxxflags>-fdiagnostics-show-option 
+        <toolset>gcc-4.6.0,<target-os>windows:<cxxflags>-fdiagnostics-show-option 
+        <toolset>gcc-4.6.3,<target-os>windows:<cxxflags>-fdiagnostics-show-option 
+        <toolset>gcc-4.7.0,<target-os>windows:<cxxflags>-fdiagnostics-show-option 
+        <toolset>gcc-4.8.0,<target-os>windows:<cxxflags>-fdiagnostics-show-option 
         <toolset>msvc:<cxxflags>/wd4512
 
 # Note: Some of the remarks from the Intel compiler are disabled
@@ -74,15 +72,13 @@ project boost/chrono
         <toolset>intel:<cxxflags>-wd193,304,383,444
         <toolset>intel:<cxxflags>-wd593,981
         <toolset>intel:<cxxflags>-wd1418
-	  <toolset>intel:<cxxflags>-wd2415
+        <toolset>intel:<cxxflags>-wd2415
 
 
 
     : usage-requirements  # pass these requirement to dependents (i.e. users)
         <threading>single:<define>BOOST_CHRONO_THREAD_DISABLED
-        <library>/boost/system//boost_system
         #<define>BOOST_ERROR_CODE_HEADER_ONLY
-        #<define>BOOST_SYSTEM_INLINED
         #<define>BOOST_COMMON_TYPE_USES_STATIC_ASSERT
         #<define>BOOST_RATIO_USES_STATIC_ASSERT
         #<define>BOOST_CHRONO_USES_STATIC_ASSERT
@@ -101,7 +97,7 @@ project boost/chrono
         <toolset>gcc-3.4.4:<linkflags>--enable-auto-import
         <toolset>gcc-4.3.4:<linkflags>--enable-auto-import
         <toolset>gcc-4.4.0,<target-os>windows:<linkflags>--enable-auto-import 
- 	<toolset>gcc-4.5.0,<target-os>windows:<linkflags>--enable-auto-import 
+        <toolset>gcc-4.5.0,<target-os>windows:<linkflags>--enable-auto-import 
     ;
 
 SOURCES = chrono thread_clock process_cpu_clocks ;

--- a/doc/chrono.qbk
+++ b/doc/chrono.qbk
@@ -109,7 +109,6 @@
 [template chrono_conf[link_text] [link chrono.reference.cpp0x.chrono_chrono_hpp.conf [link_text]]]
 
 [def __BOOST_CHRONO_HEADER_ONLY [link chrono.reference.cpp0x.chrono_chrono_hpp.conf.header_only `BOOST_CHRONO_HEADER_ONLY`]]
-[def __BOOST_SYSTEM_INLINED `BOOST_SYSTEM_INLINED`]
 
 [def __BOOST_CHRONO_USES_STATIC_ASSERT [chrono_conf `BOOST_CHRONO_USES_STATIC_ASSERT`]]
 [def __BOOST_CHRONO_USES_MPL_ASSERT [chrono_conf `BOOST_CHRONO_USES_MPL_ASSERT`]]

--- a/perf/Jamfile.v2
+++ b/perf/Jamfile.v2
@@ -33,8 +33,8 @@ project
         <toolset>clang:<cxxflags>-Wextra
         <toolset>clang:<cxxflags>-pedantic
         <toolset>clang:<cxxflags>-Wno-long-long
-        <toolset>gcc-4.5.0,<target-os>windows:<cxxflags>-Wno-missing-field-initializers 
- 	<toolset>gcc-4.5.0,<target-os>windows:<cxxflags>-fdiagnostics-show-option 
+        <toolset>gcc-4.5.0,<target-os>windows:<cxxflags>-Wno-missing-field-initializers
+        <toolset>gcc-4.5.0,<target-os>windows:<cxxflags>-fdiagnostics-show-option
         <toolset>msvc:<cxxflags>/wd4127
 # Note: Some of the remarks from the Intel compiler are disabled
 # remark #304: access control not specified ("public" by default)
@@ -50,19 +50,14 @@ rule chrono-run ( sources )
     [ run $(sources) ../build//boost_chrono
         : :
         :
-            <library>/boost/system//boost_system
         :   $(sources[1]:B)_shared ]
     [ run $(sources) ../build//boost_chrono/<link>static
         : :
         :
-            <library>/boost/system//boost_system
         :   $(sources[1]:B)_static ]
     [ run $(sources)
         : :
         :   <define>BOOST_CHRONO_HEADER_ONLY
-            # comment one of the following lines
-            #<define>BOOST_SYSTEM_INLINED
-            <library>/boost/system//boost_system
         :   $(sources[1]:B)_header ]
     ;
 }
@@ -72,19 +67,14 @@ rule chrono-run2 ( sources : name )
     [ run $(sources) ../build//boost_chrono
         : :
         :
-            <library>/boost/system//boost_system
         :   $(name)_shared ]
     [ run $(sources) ../build//boost_chrono/<link>static
         : :
         :
-            <library>/boost/system//boost_system
         : $(name)_static ]
     [ run $(sources)
         : :
         :   <define>BOOST_CHRONO_HEADER_ONLY
-            # comment one of the following lines
-            #<define>BOOST_SYSTEM_INLINED
-            <library>/boost/system//boost_system
         : $(name)_header ]
     ;
 }
@@ -96,19 +86,14 @@ rule chrono-run-mt ( sources )
     [ run $(sources) ../build//boost_chrono
         : :
         :
-            <library>/boost/system//boost_system
         :   $(sources[1]:B)_shared ]
     [ run $(sources) ../build//boost_chrono/<link>static
         : :
         :
-            <library>/boost/system//boost_system
         :  $(sources[1]:B)_static ]
     [ run $(sources)
         : :
         :   <define>BOOST_CHRONO_HEADER_ONLY
-            # comment one of the following lines
-            #<define>BOOST_SYSTEM_INLINED
-            <library>/boost/system//boost_system
         :   $(sources[1]:B)_header ]
     ;
 }
@@ -128,9 +113,6 @@ rule chrono-run2-mt ( sources : name )
     [ run $(sources)
         : :
         :   <define>BOOST_CHRONO_HEADER_ONLY
-            # comment one of the following lines
-            #<define>BOOST_SYSTEM_INLINED
-            <library>/boost/system//boost_system
         : $(name)_header ]
     ;
 }
@@ -142,8 +124,6 @@ rule chrono-compile ( sources )
         : $(sources[1]:B)_lib ]
     [ compile $(sources)
         :   <define>BOOST_CHRONO_HEADER_ONLY
-            # comment the following line
-            <define>BOOST_SYSTEM_INLINED
         : $(sources[1]:B)_header ]
     ;
 }
@@ -156,8 +136,6 @@ rule chrono-compile2 ( sources : name )
         : $(name)_lib ]
     [ compile $(sources)
         :  <define>BOOST_CHRONO_HEADER_ONLY
-            # comment the following line
-            <define>BOOST_SYSTEM_INLINED
         : $(name)_header ]
     ;
 }

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -42,7 +42,7 @@ project
         <toolset>clang:<cxxflags>-Wno-long-long
         <toolset>clang:<cxxflags>-Wno-variadic-macros
         <toolset>gcc-4.5.0,<target-os>windows:<cxxflags>-Wno-missing-field-initializers 
- 	<toolset>gcc-4.5.0,<target-os>windows:<cxxflags>-fdiagnostics-show-option 
+        <toolset>gcc-4.5.0,<target-os>windows:<cxxflags>-fdiagnostics-show-option 
         <toolset>msvc:<cxxflags>/wd4127
         <toolset>msvc:<cxxflags>/wd4512
 # Note: Some of the remarks from the Intel compiler are disabled
@@ -58,7 +58,7 @@ project
         <toolset>intel:<cxxflags>-wd193,304,383,444
         <toolset>intel:<cxxflags>-wd593,981
         <toolset>intel:<cxxflags>-wd1418
-	  <toolset>intel:<cxxflags>-wd2415
+        <toolset>intel:<cxxflags>-wd2415
     ;
 
 rule chrono-run ( sources )
@@ -67,13 +67,11 @@ rule chrono-run ( sources )
     [ run $(sources) ../build//boost_chrono
         : :
         :
-            <library>/boost/system//boost_system
             <define>BOOST_CHRONO_VERSION=2
         :   $(sources[1]:B)_d  ]
     #[ run $(sources) ../build//boost_chrono/<link>static
     #    : :
     #    :
-    #        <library>/boost/system//boost_system/<link>static
     #    :   $(sources[1]:B)_s ]
     [ run $(sources)
         : :
@@ -91,13 +89,11 @@ rule chrono-runXXX ( sources )
     [ run $(sources) ../build//boost_chrono
         : :
         :
-            <library>/boost/system//boost_system
             <define>BOOST_CHRONO_VERSION=2
         :   $(sources[1]:B)_d  ]
     #[ run $(sources) ../build//boost_chrono/<link>static
     #    : :
     #    :
-    #        <library>/boost/system//boost_system/<link>static
     #    :   $(sources[1]:B)_s ]
     [ run $(sources)
         : :
@@ -116,13 +112,11 @@ rule chrono-v1-v2-run ( sources )
     [ run $(sources) ../build//boost_chrono
         : :
         :
-            <library>/boost/system//boost_system
             <define>BOOST_CHRONO_VERSION=2
         :   $(sources[1]:B)_d  ]
     [ run $(sources) ../build//boost_chrono/<link>static
         : :
         :
-            <library>/boost/system//boost_system/<link>static
         :   v1_$(sources[1]:B)_s ]
     [ run $(sources)
         : :
@@ -147,13 +141,11 @@ rule chrono-run2 ( sources : name )
     [ run $(sources) ../build//boost_chrono
         : :
         :
-            <library>/boost/system//boost_system
             <define>BOOST_CHRONO_VERSION=2
         :   $(name)_d  ]
     #[ run $(sources) ../build//boost_chrono/<link>static
     #    : :
     #    :
-    #        <library>/boost/system//boost_system/<link>static
     #    : $(name)_s ]
     [ run $(sources)
         : :
@@ -171,7 +163,6 @@ rule date-run ( sources + )
     [ run $(sources) ../build//boost_chrono
         : :
         :
-            <library>/boost/system//boost_system
             <define>BOOST_CHRONO_VERSION=2
         :   $(sources[1]:B)_d  ]
     ;
@@ -183,7 +174,6 @@ rule date-run-2 ( sources + : name )
     [ run $(sources) ../build//boost_chrono
         : :
         :
-            <library>/boost/system//boost_system
             <define>BOOST_CHRONO_VERSION=2
         :   $(name)_d  ]
     ;
@@ -196,13 +186,11 @@ rule chrono-run-mt ( sources )
     [ run $(sources) ../build//boost_chrono
         : :
         :
-            <library>/boost/system//boost_system
             <define>BOOST_CHRONO_VERSION=2
         :   $(sources[1]:B)_d  ]
     #[ run $(sources) ../build//boost_chrono/<link>static
     #    : :
     #    :
-    #        <library>/boost/system//boost_system/<link>static
     #    :  $(sources[1]:B)_s ]
     [ run $(sources)
         : :
@@ -219,13 +207,11 @@ rule chrono-run2-mt ( sources * : name )
     [ run $(sources) ../build//boost_chrono
         : :
         :
-            <library>/boost/system//boost_system
             <define>BOOST_CHRONO_VERSION=2
         :   $(name)_d  ]
     #[ run $(sources) ../build//boost_chrono/<link>static
     #    : :
     #    :
-    #        <library>/boost/system//boost_system/<link>static
     #    : $(name)_s ]
     [ run $(sources)
         : :
@@ -243,13 +229,11 @@ rule chrono-run-check ( sources )
     [ run $(sources)
         : :
         :
-            <library>/boost/system//boost_system
             <define>BOOST_CHRONO_VERSION=2
         :   $(sources[1]:B)_d  ]
     [ run $(sources)
         : :
         :
-            <library>/boost/system//boost_system/<link>static
             <define>BOOST_CHRONO_VERSION=2
         :   $(sources[1]:B)_s ]
     [ run $(sources)
@@ -268,13 +252,11 @@ rule chrono-run-check2 ( sources : name )
     [ run $(sources)
         : :
         :
-            <library>/boost/system//boost_system
             <define>BOOST_CHRONO_VERSION=2
         :   $(name)_d  ]
     [ run $(sources)
         : :
         :
-            <library>/boost/system//boost_system/<link>static
             <define>BOOST_CHRONO_VERSION=2
         : $(name)_s ]
     [ run $(sources)
@@ -458,7 +440,7 @@ rule chrono-compile2 ( sources : name )
     test-suite "io"
         :
         [ chrono-v1-v2-run-header io/duration_input.cpp  ]
-        [ chrono-v1-v2-run-header io/duration_output.cpp  ]      
+        [ chrono-v1-v2-run-header io/duration_output.cpp  ]
         [ chrono-v1-v2-run-header io/time_point_input.cpp  ]
         [ chrono-v1-v2-run-header io/time_point_output.cpp  ]
         [ chrono-run test_7868.cpp  ]


### PR DESCRIPTION
Since Boost.System is now header-only, no need to link with the library.