### PR TITLE
Rename xtime to xtime_ to avoid conflict with MSVC's ::xtime

### DIFF
--- a/example/xtime.cpp
+++ b/example/xtime.cpp
@@ -47,39 +47,40 @@ round_up(duration<Rep, Period> d)
 
 // demonstrate interaction with xtime-like facility:
 
-struct xtime
+// msvc defines ::xtime in <mutex>, so we use xtime_
+struct xtime_
 {
     long sec;
     unsigned long usec;
 };
 
 template <class Rep, class Period>
-xtime
+xtime_
 to_xtime_truncate(duration<Rep, Period> d)
 {
-    xtime xt;
+    xtime_ xt;
     xt.sec = static_cast<long>(duration_cast<seconds>(d).count());
     xt.usec = static_cast<long>(duration_cast<microseconds>(d - seconds(xt.sec)).count());
     return xt;
 }
 
 template <class Rep, class Period>
-xtime
+xtime_
 to_xtime_round_up(duration<Rep, Period> d)
 {
-    xtime xt;
+    xtime_ xt;
     xt.sec = static_cast<long>(duration_cast<seconds>(d).count());
     xt.usec = static_cast<unsigned long>(round_up<microseconds>(d - seconds(xt.sec)).count());
     return xt;
 }
 
 microseconds
-from_xtime(xtime xt)
+from_xtime(xtime_ xt)
 {
     return seconds(xt.sec) + microseconds(xt.usec);
 }
 
-void print(xtime xt)
+void print(xtime_ xt)
 {
     std::cout << '{' << xt.sec << ',' << xt.usec << "}\n";
 }
@@ -87,7 +88,7 @@ void print(xtime xt)
 void test_with_xtime()
 {
     std::cout << "test_with_xtime\n";
-    xtime xt = to_xtime_truncate(seconds(3) + milliseconds(251));
+    xtime_ xt = to_xtime_truncate(seconds(3) + milliseconds(251));
     print(xt);
     milliseconds ms = duration_cast<milliseconds>(from_xtime(xt));
     std::cout << ms.count() << " milliseconds\n";


### PR DESCRIPTION
As pointed out in https://github.com/boostorg/system/issues/44, including `<mutex>` defines `struct xtime` in the global namespace.