### PR TITLE
Avoid using deprecated headers to silence compiler warnings

### DIFF
--- a/include/boost/chrono/io/duration_io.hpp
+++ b/include/boost/chrono/io/duration_io.hpp
@@ -17,7 +17,7 @@
 #include <boost/chrono/io/duration_put.hpp>
 #include <boost/chrono/io/duration_get.hpp>
 #include <boost/chrono/io/utility/manip_base.hpp>
-#include <boost/detail/no_exceptions_support.hpp>
+#include <boost/core/no_exceptions_support.hpp>
 #include <boost/type_traits/is_integral.hpp>
 #include <boost/type_traits/is_floating_point.hpp>
 #include <locale>

--- a/include/boost/chrono/io/duration_style.hpp
+++ b/include/boost/chrono/io/duration_style.hpp
@@ -10,7 +10,7 @@
 #ifndef BOOST_CHRONO_IO_DURATION_STYLE_HPP
 #define BOOST_CHRONO_IO_DURATION_STYLE_HPP
 
-#include <boost/detail/scoped_enum_emulation.hpp>
+#include <boost/core/scoped_enum.hpp>
 
 namespace boost
 {

--- a/include/boost/chrono/io/time_point_io.hpp
+++ b/include/boost/chrono/io/time_point_io.hpp
@@ -29,7 +29,7 @@
 #include <boost/chrono/round.hpp>
 #include <boost/chrono/detail/scan_keyword.hpp>
 #include <boost/static_assert.hpp>
-#include <boost/detail/no_exceptions_support.hpp>
+#include <boost/core/no_exceptions_support.hpp>
 #include <cstring>
 #include <locale>
 #include <ctime>

--- a/include/boost/chrono/io/timezone.hpp
+++ b/include/boost/chrono/io/timezone.hpp
@@ -9,7 +9,8 @@
 
 #ifndef BOOST_CHRONO_IO_TIMEZONE_HPP
 #define BOOST_CHRONO_IO_TIMEZONE_HPP
-#include <boost/detail/scoped_enum_emulation.hpp>
+
+#include <boost/core/scoped_enum.hpp>
 
 namespace boost
 {


### PR DESCRIPTION
The deprecated headers will be removed in a future release.