### PR TITLE
Fixed zero as null pointer error in G++

### DIFF
--- a/include/boost/chrono/config.hpp
+++ b/include/boost/chrono/config.hpp
@@ -170,6 +170,12 @@
 #define BOOST_CHRONO_INLINE
 #define BOOST_CHRONO_STATIC static
 
+#ifdef BOOST_NO_CXX11_NULLPTR
+#   define BOOST_CHRONO_NULL NULL
+#else
+#   define BOOST_CHRONO_NULL nullptr
+#endif
+
 //  enable dynamic linking on Windows  ---------------------------------------//
 
 // we need to import/export our code only if the user has specifically

--- a/include/boost/chrono/duration.hpp
+++ b/include/boost/chrono/duration.hpp
@@ -455,7 +455,7 @@ namespace chrono {
                             >
                         >
                     >
-                >::type* = 0
+                >::type* = BOOST_CHRONO_NULL
             ) : rep_(r) { }
 #if  defined   BOOST_NO_CXX11_DEFAULTED_FUNCTIONS
         duration& operator=(const duration& rhs)
@@ -478,7 +478,7 @@ namespace chrono {
                             mpl::not_ < treat_as_floating_point<Rep2> >
                         >
                     >
-                >::type* = 0
+                >::type* = BOOST_CHRONO_NULL
         )
             : rep_(chrono::detail::duration_cast<duration<Rep2, Period2>, duration>()(d).count()) {}
 

--- a/include/boost/chrono/io/duration_put.hpp
+++ b/include/boost/chrono/io/duration_put.hpp
@@ -102,7 +102,7 @@ namespace boost
        */
       template <typename Rep, typename Period>
       iter_type put(iter_type s, std::ios_base& ios, char_type fill, duration<Rep, Period> const& d, const CharT* pattern,
-          const CharT* pat_end, const char_type* val = 0) const
+          const CharT* pat_end, const char_type* val = BOOST_CHRONO_NULL) const
       {
         if (std::has_facet<duration_units<CharT> >(ios.getloc()))
         {
@@ -119,7 +119,7 @@ namespace boost
 
       template <typename Rep, typename Period>
       iter_type put(duration_units<CharT> const& units_facet, iter_type s, std::ios_base& ios, char_type fill,
-          duration<Rep, Period> const& d, const CharT* pattern, const CharT* pat_end, const char_type* val = 0) const
+          duration<Rep, Period> const& d, const CharT* pattern, const CharT* pat_end, const char_type* val = BOOST_CHRONO_NULL) const
       {
 
         const std::ctype<char_type>& ct = std::use_facet<std::ctype<char_type> >(ios.getloc());
@@ -170,7 +170,7 @@ namespace boost
        * @Returns An iterator pointing immediately after the last character produced.
        */
       template <typename Rep, typename Period>
-      iter_type put(iter_type s, std::ios_base& ios, char_type fill, duration<Rep, Period> const& d, const char_type* val = 0) const
+      iter_type put(iter_type s, std::ios_base& ios, char_type fill, duration<Rep, Period> const& d, const char_type* val = BOOST_CHRONO_NULL) const
       {
         if (std::has_facet<duration_units<CharT> >(ios.getloc()))
         {
@@ -198,7 +198,7 @@ namespace boost
        * @Returns s, iterator pointing immediately after the last character produced.
        */
       template <typename Rep, typename Period>
-      iter_type put_value(iter_type s, std::ios_base& ios, char_type fill, duration<Rep, Period> const& d, const char_type* val = 0) const
+      iter_type put_value(iter_type s, std::ios_base& ios, char_type fill, duration<Rep, Period> const& d, const char_type* val = BOOST_CHRONO_NULL) const
       {
         if (val)
         {
@@ -213,7 +213,7 @@ namespace boost
       }
 
       template <typename Rep, typename Period>
-      iter_type put_value(iter_type s, std::ios_base& ios, char_type fill, duration<process_times<Rep>, Period> const& d, const char_type* = 0) const
+      iter_type put_value(iter_type s, std::ios_base& ios, char_type fill, duration<process_times<Rep>, Period> const& d, const char_type* = BOOST_CHRONO_NULL) const
       {
         *s++ = CharT('{');
         s = put_value(s, ios, fill, process_real_cpu_clock::duration(d.count().real));

--- a/include/boost/chrono/time_point.hpp
+++ b/include/boost/chrono/time_point.hpp
@@ -182,7 +182,7 @@ namespace chrono {
                 , typename boost::enable_if
                 <
                     boost::is_convertible<Duration2, duration>
-                >::type* = 0
+                >::type* = BOOST_CHRONO_NULL
         )
             : d_(t.time_since_epoch())
         {


### PR DESCRIPTION
Fixed the error shown in https://github.com/boostorg/chrono/issues/48 

This was done by creating and using a macro in config.hpp allowing nullptr to be used if it is available without breaking C++98 compatibility.