### PR TITLE
Fix -Wdeprecated-copy for duration

### DIFF
--- a/include/boost/chrono/duration.hpp
+++ b/include/boost/chrono/duration.hpp
@@ -463,9 +463,12 @@ namespace chrono {
             if (&rhs != this) rep_= rhs.rep_;
             return *this;
         }
+        duration(const duration& rhs) : rep_(rhs.rep_) {}
 #else
         duration& operator=(const duration& rhs) = default;
+        duration(const duration&) = default;
 #endif
+
         // conversions
         template <class Rep2, class Period2>
         BOOST_FORCEINLINE BOOST_CONSTEXPR


### PR DESCRIPTION
Adds definition of copy constructor for `boost::chrono::duration` to fix `warning: definition of implicit copy constructor for 'duration' is deprecated because it has a user-declared copy assignment operator`.