### PR TITLE
Add support for modular build structure.

### DIFF
--- a/build.jam
+++ b/build.jam
@@ -1,0 +1,35 @@
+# Copyright René Ferdinand Rivera Morell 2023
+# Distributed under the Boost Software License, Version 1.0.
+# (See accompanying file LICENSE_1_0.txt or copy at
+# http://www.boost.org/LICENSE_1_0.txt)
+
+import project ;
+
+project /boost/chrono
+    : common-requirements
+        <source>/boost/assert//boost_assert
+        <source>/boost/config//boost_config
+        <source>/boost/core//boost_core
+        <source>/boost/integer//boost_integer
+        <source>/boost/move//boost_move
+        <source>/boost/mpl//boost_mpl
+        <source>/boost/predef//boost_predef
+        <source>/boost/ratio//boost_ratio
+        <source>/boost/static_assert//boost_static_assert
+        <source>/boost/system//boost_system
+        <source>/boost/throw_exception//boost_throw_exception
+        <source>/boost/type_traits//boost_type_traits
+        <source>/boost/typeof//boost_typeof
+        <source>/boost/utility//boost_utility
+        <source>/boost/winapi//boost_winapi
+        <include>include
+    ;
+
+explicit
+    [ alias boost_chrono : build//boost_chrono ]
+    [ alias all : boost_chrono test ]
+    ;
+
+call-if : boost-library chrono
+    : install boost_chrono
+    ;

--- a/build.jam
+++ b/build.jam
@@ -7,21 +7,21 @@ import project ;
 
 project /boost/chrono
     : common-requirements
-        <source>/boost/assert//boost_assert
-        <source>/boost/config//boost_config
-        <source>/boost/core//boost_core
-        <source>/boost/integer//boost_integer
-        <source>/boost/move//boost_move
-        <source>/boost/mpl//boost_mpl
-        <source>/boost/predef//boost_predef
-        <source>/boost/ratio//boost_ratio
-        <source>/boost/static_assert//boost_static_assert
-        <source>/boost/system//boost_system
-        <source>/boost/throw_exception//boost_throw_exception
-        <source>/boost/type_traits//boost_type_traits
-        <source>/boost/typeof//boost_typeof
-        <source>/boost/utility//boost_utility
-        <source>/boost/winapi//boost_winapi
+        <library>/boost/assert//boost_assert
+        <library>/boost/config//boost_config
+        <library>/boost/core//boost_core
+        <library>/boost/integer//boost_integer
+        <library>/boost/move//boost_move
+        <library>/boost/mpl//boost_mpl
+        <library>/boost/predef//boost_predef
+        <library>/boost/ratio//boost_ratio
+        <library>/boost/static_assert//boost_static_assert
+        <library>/boost/system//boost_system
+        <library>/boost/throw_exception//boost_throw_exception
+        <library>/boost/type_traits//boost_type_traits
+        <library>/boost/typeof//boost_typeof
+        <library>/boost/utility//boost_utility
+        <library>/boost/winapi//boost_winapi
         <include>include
     ;
 

--- a/build.jam
+++ b/build.jam
@@ -3,6 +3,8 @@
 # (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)
 
+require-b2 5.1 ;
+
 import project ;
 
 project /boost/chrono

--- a/build.jam
+++ b/build.jam
@@ -3,9 +3,7 @@
 # (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)
 
-require-b2 5.1 ;
-
-import project ;
+require-b2 5.2 ;
 
 project /boost/chrono
     : common-requirements

--- a/build/Jamfile.v2
+++ b/build/Jamfile.v2
@@ -8,6 +8,7 @@
 
 # See library home page at http://www.boost.org/libs/chrono
 
+import-search /boost/config/checks ;
 import config : requires ;
 
 local cxx11-requirements = [ requires cxx11_hdr_ratio cxx11_template_aliases cxx11_decltype cxx11_char16_t cxx11_char32_t ] ;

--- a/build/Jamfile.v2
+++ b/build/Jamfile.v2
@@ -52,12 +52,12 @@ project
         <toolset>clang:<warnings>pedantic
         <toolset>clang:<cxxflags>-Wno-long-long
         <toolset>clang:<cxxflags>-Wno-variadic-macros
-        <toolset>gcc-4.4.0,<target-os>windows:<cxxflags>-fdiagnostics-show-option 
-        <toolset>gcc-4.5.0,<target-os>windows:<cxxflags>-fdiagnostics-show-option 
-        <toolset>gcc-4.6.0,<target-os>windows:<cxxflags>-fdiagnostics-show-option 
-        <toolset>gcc-4.6.3,<target-os>windows:<cxxflags>-fdiagnostics-show-option 
-        <toolset>gcc-4.7.0,<target-os>windows:<cxxflags>-fdiagnostics-show-option 
-        <toolset>gcc-4.8.0,<target-os>windows:<cxxflags>-fdiagnostics-show-option 
+        <toolset>gcc-4.4.0,<target-os>windows:<cxxflags>-fdiagnostics-show-option
+        <toolset>gcc-4.5.0,<target-os>windows:<cxxflags>-fdiagnostics-show-option
+        <toolset>gcc-4.6.0,<target-os>windows:<cxxflags>-fdiagnostics-show-option
+        <toolset>gcc-4.6.3,<target-os>windows:<cxxflags>-fdiagnostics-show-option
+        <toolset>gcc-4.7.0,<target-os>windows:<cxxflags>-fdiagnostics-show-option
+        <toolset>gcc-4.8.0,<target-os>windows:<cxxflags>-fdiagnostics-show-option
         <toolset>msvc:<cxxflags>/wd4512
 
 # Note: Some of the remarks from the Intel compiler are disabled
@@ -95,10 +95,11 @@ project
 
         <link>shared:<define>BOOST_CHRONO_DYN_LINK=1
         <link>static:<define>BOOST_CHRONO_STATIC_LINK=1
+        <define>BOOST_CHRONO_NO_LIB=1
         <toolset>gcc-3.4.4:<linkflags>--enable-auto-import
         <toolset>gcc-4.3.4:<linkflags>--enable-auto-import
-        <toolset>gcc-4.4.0,<target-os>windows:<linkflags>--enable-auto-import 
-        <toolset>gcc-4.5.0,<target-os>windows:<linkflags>--enable-auto-import 
+        <toolset>gcc-4.4.0,<target-os>windows:<linkflags>--enable-auto-import
+        <toolset>gcc-4.5.0,<target-os>windows:<linkflags>--enable-auto-import
     ;
 
 SOURCES = chrono thread_clock process_cpu_clocks ;

--- a/build/Jamfile.v2
+++ b/build/Jamfile.v2
@@ -12,7 +12,7 @@ import config : requires ;
 
 local cxx11-requirements = [ requires cxx11_hdr_ratio cxx11_template_aliases cxx11_decltype cxx11_char16_t cxx11_char32_t ] ;
 
-project boost/chrono
+project
     : source-location ../src
     : requirements
         <target-os>freebsd:<linkflags>"-lrt"
@@ -111,5 +111,3 @@ lib boost_chrono
     <link>shared:<define>BOOST_CHRONO_DYN_LINK=1 # tell source we're building dll's
     <link>static:<define>BOOST_CHRONO_STATIC_LINK=1 # tell source we're building static lib's
     ;
-
-boost-install boost_chrono ;

--- a/perf/Jamfile.v2
+++ b/perf/Jamfile.v2
@@ -13,9 +13,9 @@ import feature ;
 
 project
     : requirements
-        <target-os>freebsd:<linkflags>"-lrt" 
-        <target-os>linux:<linkflags>"-lrt" 
-        <toolset>pgi:<linkflags>"-lrt" 
+        <target-os>freebsd:<linkflags>"-lrt"
+        <target-os>linux:<linkflags>"-lrt"
+        <toolset>pgi:<linkflags>"-lrt"
         #<threading>single:<define>BOOST_CHRONO_THREAD_DISABLED
         <toolset>msvc:<asynch-exceptions>on
         <define>BOOST_CHRONO_USES_MPL_ASSERT
@@ -42,6 +42,7 @@ project
 # remark #1418: external function definition with no prior declaration
         <toolset>intel:<cxxflags>-wd304,383,1418
         <define>BOOST_CHRONO_VERSION=2
+        <include>../example
     ;
 
 rule chrono-run ( sources )

--- a/perf/store_now_in_vector.cpp
+++ b/perf/store_now_in_vector.cpp
@@ -6,7 +6,7 @@
 
 #include <boost/chrono/chrono.hpp>
 #include <boost/chrono/chrono_io.hpp>
-#include <libs/chrono/example/timer.hpp>
+#include <timer.hpp>
 #include <boost/chrono/process_cpu_clocks.hpp>
 #include <vector>
 

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -41,8 +41,8 @@ project
         <toolset>clang:<cxxflags>-pedantic
         <toolset>clang:<cxxflags>-Wno-long-long
         <toolset>clang:<cxxflags>-Wno-variadic-macros
-        <toolset>gcc-4.5.0,<target-os>windows:<cxxflags>-Wno-missing-field-initializers 
-        <toolset>gcc-4.5.0,<target-os>windows:<cxxflags>-fdiagnostics-show-option 
+        <toolset>gcc-4.5.0,<target-os>windows:<cxxflags>-Wno-missing-field-initializers
+        <toolset>gcc-4.5.0,<target-os>windows:<cxxflags>-fdiagnostics-show-option
         <toolset>msvc:<cxxflags>/wd4127
         <toolset>msvc:<cxxflags>/wd4512
 # Note: Some of the remarks from the Intel compiler are disabled
@@ -445,7 +445,7 @@ rule chrono-compile2 ( sources : name )
         [ chrono-v1-v2-run-header io/time_point_output.cpp  ]
         [ chrono-run test_7868.cpp  ]
         [ chrono-run test_11006.cpp  ]
-        [ chrono-run test_11012.cpp  ]
+        [ chrono-run test_11012.cpp /boost/rational//boost_rational ]
         [ chrono-runXXX test_12176.cpp  ]
         ;
 

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -59,6 +59,7 @@ project
         <toolset>intel:<cxxflags>-wd593,981
         <toolset>intel:<cxxflags>-wd1418
         <toolset>intel:<cxxflags>-wd2415
+        <library>/boost/rational//boost_rational
     ;
 
 rule chrono-run ( sources )
@@ -445,7 +446,7 @@ rule chrono-compile2 ( sources : name )
         [ chrono-v1-v2-run-header io/time_point_output.cpp  ]
         [ chrono-run test_7868.cpp  ]
         [ chrono-run test_11006.cpp  ]
-        [ chrono-run test_11012.cpp /boost/rational//boost_rational ]
+        [ chrono-run test_11012.cpp ]
         [ chrono-runXXX test_12176.cpp  ]
         ;
 


### PR DESCRIPTION
This is part of the effort to make the Boost libraries "modular" for build and consumption. See https://lists.boost.org/Archives/boost/2024/01/255704.php and https://github.com/grafikrobot/boost-b2-modular/blob/b2-modular/README.adoc for more information.

This PR depends on the following other PRs being merged to both develop and master branches of the respective repos:

- https://github.com/boostorg/boost/pull/854
- https://github.com/boostorg/auto_index/pull/7
- https://github.com/boostorg/bcp/pull/20
- https://github.com/boostorg/boost_install/pull/69
- https://github.com/boostorg/boost/pull/890
- https://github.com/boostorg/boostbook/pull/25
- https://github.com/boostorg/boostdep/pull/21
- https://github.com/boostorg/docca/pull/143
- https://github.com/boostorg/inspect/pull/19
- https://github.com/boostorg/quickbook/pull/25

This PR will be changed to ready for review, i.e. not draft, when the above are merged. Do not merge this one until that time.