### PR TITLE
Replace GetSystemTimeAsFileTime with GetSystemTimePreciseAsFileTime

### DIFF
--- a/doc/chrono.qbk
+++ b/doc/chrono.qbk
@@ -7745,7 +7745,7 @@ This operator is convenient for computing where in a time frame a given duration
 The following table presents a resume of which API is used for each clock on each platform
 [table Clock API correspondence
     [[Clock]                                [Windows Platform]          [Posix Platform]                 [Mac Platform]  ]
-    [[__system_clock]                     [GetSystemTimeAsFileTime]   [clock_gettime( CLOCK_REALTIME)] [gettimeofday]          ]
+    [[__system_clock]                     [GetSystemTimePreciseAsFileTime ]   [clock_gettime( CLOCK_REALTIME)] [gettimeofday]          ]
     [[__steady_clock]                  [QueryPerformanceCounter and QueryPerformanceFrequency]
                                         [clock_gettime( CLOCK_STEADY)] [mach_timebase_info,mach_absolute_time]          ]
     [[__process_real_cpu_clock]           [GetProcessTimes]           [times]                         [times]  ]

--- a/example/runtime_resolution.cpp
+++ b/example/runtime_resolution.cpp
@@ -55,12 +55,12 @@ namespace
   {
     FILETIME ft;
   #if defined(UNDER_CE)
-    // Windows CE does not define GetSystemTimeAsFileTime so we do it in two steps.
+    // Windows CE does not define GetSystemTimePreciseAsFileTime  so we do it in two steps.
     SYSTEMTIME st;
     ::GetSystemTime( &st );
     ::SystemTimeToFileTime( &st, &ft );
   #else
-    ::GetSystemTimeAsFileTime( &ft );  // never fails
+    ::GetSystemTimePreciseAsFileTime ( &ft );  // never fails
   #endif
     long long t = (static_cast<long long>(ft.dwHighDateTime) << 32) | ft.dwLowDateTime;
   # if !defined( BOOST_MSVC ) || BOOST_MSVC > 1300 // > VC++ 7.0

--- a/example/time2_demo.cpp
+++ b/example/time2_demo.cpp
@@ -48,7 +48,7 @@ namespace
   int gettimeofday(struct timeval * tp, void *)
   {
     FILETIME ft;
-    ::GetSystemTimeAsFileTime( &ft );  // never fails
+    ::GetSystemTimePreciseAsFileTime ( &ft );  // never fails
     long long t = (static_cast<long long>(ft.dwHighDateTime) << 32) | ft.dwLowDateTime;
   # if !defined( BOOST_MSVC ) || BOOST_MSVC > 1300 // > VC++ 7.0
     t -= 116444736000000000LL;

--- a/example/timeval_demo.cpp
+++ b/example/timeval_demo.cpp
@@ -57,12 +57,12 @@ namespace
   {
     FILETIME ft;
   #if defined(UNDER_CE)
-    // Windows CE does not define GetSystemTimeAsFileTime so we do it in two steps.
+    // Windows CE does not define GetSystemTimePreciseAsFileTime  so we do it in two steps.
     SYSTEMTIME st;
     ::GetSystemTime( &st );
     ::SystemTimeToFileTime( &st, &ft );
   #else
-    ::GetSystemTimeAsFileTime( &ft );  // never fails
+    ::GetSystemTimePreciseAsFileTime ( &ft );  // never fails
   #endif
     long long t = (static_cast<long long>(ft.dwHighDateTime) << 32) | ft.dwLowDateTime;
   # if !defined( BOOST_MSVC ) || BOOST_MSVC > 1300 // > VC++ 7.0

--- a/include/boost/chrono/detail/inlined/win/chrono.hpp
+++ b/include/boost/chrono/detail/inlined/win/chrono.hpp
@@ -100,7 +100,7 @@ namespace chrono_detail
   system_clock::time_point system_clock::now() BOOST_NOEXCEPT
   {
     boost::winapi::FILETIME_ ft;
-    boost::winapi::GetSystemTimeAsFileTime( &ft );  // never fails
+    boost::winapi::GetSystemTimePreciseAsFileTime ( &ft );  // never fails
     return system_clock::time_point(
       system_clock::duration(
         ((static_cast<__int64>( ft.dwHighDateTime ) << 32) | ft.dwLowDateTime)
@@ -115,7 +115,7 @@ namespace chrono_detail
   system_clock::time_point system_clock::now( system::error_code & ec )
   {
     boost::winapi::FILETIME_ ft;
-    boost::winapi::GetSystemTimeAsFileTime( &ft );  // never fails
+    boost::winapi::GetSystemTimePreciseAsFileTime ( &ft );  // never fails
     if (!::boost::chrono::is_throws(ec))
     {
         ec.clear();


### PR DESCRIPTION
According to Microsoft documentation this variant of GetSystemTime guarantiees to get highest posible level of precision (<1us). https://learn.microsoft.com/en-us/windows/win32/api/sysinfoapi/nf-sysinfoapi-getsystemtimepreciseasfiletime

this is for #79
