### PR TITLE
Remove dependencies on Boost.StaticAssert

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,7 +27,6 @@ target_link_libraries(boost_chrono
     Boost::mpl
     Boost::predef
     Boost::ratio
-    Boost::static_assert
     Boost::system
     Boost::throw_exception
     Boost::type_traits

--- a/build.jam
+++ b/build.jam
@@ -14,7 +14,6 @@ constant boost_dependencies :
     /boost/mpl//boost_mpl
     /boost/predef//boost_predef
     /boost/ratio//boost_ratio
-    /boost/static_assert//boost_static_assert
     /boost/system//boost_system
     /boost/throw_exception//boost_throw_exception
     /boost/type_traits//boost_type_traits

--- a/test/cmake_subdir_test/CMakeLists.txt
+++ b/test/cmake_subdir_test/CMakeLists.txt
@@ -28,6 +28,7 @@ winapi
 
 # Secondary dependencies
 
+compat
 preprocessor
 variant2
 io

--- a/test/cmake_subdir_test/CMakeLists.txt
+++ b/test/cmake_subdir_test/CMakeLists.txt
@@ -19,7 +19,6 @@ move
 mpl
 predef
 ratio
-static_assert
 system
 throw_exception
 type_traits


### PR DESCRIPTION
Boost.StaticAssert has been merged into Boost.Config, so remove the dependency.